### PR TITLE
Removed bitHound urls from readme (bitHound is closed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-[![bitHound Dependencies](https://www.bithound.io/github/ipatalas/vscode-totalcommander/badges/dependencies.svg)](https://www.bithound.io/github/ipatalas/vscode-totalcommander/master/dependencies/npm)
-[![bitHound Code](https://www.bithound.io/github/ipatalas/vscode-totalcommander/badges/code.svg)](https://www.bithound.io/github/ipatalas/vscode-totalcommander)
-
 # Total Commander Launcher
 
 This extension allows you to open Total Commander in path of an actively edited file.


### PR DESCRIPTION
Hi Irek,

See: http://bithound.io/

"We are saddened to say that we were not successful in proving the
viability of this business model over the 4 year life-span of bitHound.
As such we were forced to make the very tough decision to windup the
company and discontinue our analysis service."